### PR TITLE
GraphGet

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015", "stage-0"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,9 @@ module.exports = {
   env: {
     'browser': true,
     'es6': true
+  },
+
+  rules: {
+    'comma-dangle': 'off'
   }
 };

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ graphGet(
 )
 ```
 
+## Differences between graphGet and normalizedGet
+Both functions use the same underlying recursive getter. Both map over array results. `normalizedGet` only returns the "leaf" data, the last element of the path. `graphGet` returns both the leaf and the data leading to it. `normalizedGet` works only on a single path and has no merge strategy. `graphGet` merges paths into an identity map at the root.
+
 ## Usage
 
 First bind your schemas. This makes it easy to use the getters without passing schemas and data in each time. Probably best to do this somewhere central in your project and export the bound getter.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Normalized Get
 
-A `get` function that traverses normalizr relationships.
+Helper functions for traversing [normalizr](https://github.com/paularmstrong/normalizr) relationships.
 
 ## Who is this for?
 
@@ -8,38 +8,94 @@ Anyone that uses [normalizr](https://github.com/paularmstrong/normalizr), or nor
 
 ## What does it do?
 
-Let's you access normalized data as though it was denormalized. 
+1. `NormalizedGet` lets you access normalized data using a path as though it was denormalized. 
+2. `GraphGet` lets you denormalize mutliple paths at once, perfect for using in components.
+
+### NormalizedGet
 
 Say you have a schema like this:
 ```js
   const users = new schema.Entity('users');
-  const articles = new schema.Entity('articles', {
-    author: users
+  const comments = new schema.Entity('comments', {
+    user: users
   });
-  const schemas { articles, users };
+  const articles = new schema.Entity('articles', {
+    author: users,
+    comments: [comments]
+  });
+  return { comments, articles, users };
 ```
 
-Before, to access a related property, you'd have to do this:
+Just setup `bindNoramlizedGet` like so:
 ```js
-const authorId = data.articles[123].author;
-const author = data.users[authorId];
+const normlizedGet = bindNormalizedGet(schemas, data); 
 ```
 
-The more relationships your data has have the more complex this gets. And you have to remember which property maps to which model. In this case, `articles[123].author` maps to `users`.
-
-With normalized get you can access a realtionship like:
+Now you can access deep relationships with a single line of code:
 
 ```js
-const nget = bindNormalizedGet(schemas);
-const author = nget(data, 'articles[123].author');
+// With normalizedGet
+const commenters = normlizedGet('articles[123].comments.user');
+```
+
+It even follows Array entities. So the above example will map over the comments and return the authors.
+
+For comparision, here's how you'd do it without `normlizedGet`:
+```js
+// Without normlaizedGet:
+const commenters = Object.keys(data.comments)
+  .map(key => {
+    const userId = data.comments[key].user
+    return data.users[userId];
+  });
+```
+
+The more relationships your data has have the more complex this manual fetching gets. And you have to remember which property maps to which model.
+
+### graphGet
+
+`normlizedGet` is nice for getting a specific peice of data from your entity graph. What if you need more data? That's where `graphGet` comes in handy. It returns a deep structure containing the data you specify.
+
+First we bind `graphGet` using the similar config method as before:
+```js
+const graphGet = bindGraphGet(schemas, data); 
+```
+
+Now we can retrieve the commenters as before, but also the article and comments too.
+```js
+const models = graphGet('articles[123].comments.user')
+```
+
+This will output nested data ready for use in a view:
+```js
+{
+  articles: {
+    123: {
+      title: '…',
+      comments: [{
+        comment: 'Looks good to me', 
+        user: { name: 'Jane' } 
+      }, {…}, {…}]
+    }
+  }
+}
+```
+
+`GraphGet` can accept multiple paths and merge them together.
+```js
+graphGet(
+  `articles[${articleId}].comments.user`,
+  `users[${currentUserId}]`
+)
 ```
 
 ## Usage
 
-First bind your schemas. This makes it easy to use Normalized Get without passing schemas in each time. Probably best to do this somewhere central in your project and export the bound getter.
+First bind your schemas. This makes it easy to use the getters without passing schemas and data in each time. Probably best to do this somewhere central in your project and export the bound getter.
 
 ```js
-export const nget = bindNormalizedGet(schemas);
+export const normalizedGet = bindNormalizedGet(schemas, data);
+export const graphGet = bindGraphGet(schemas, data);
 ```
 
-Now you can have an `nget` function that takes data and a path.
+Now you have `normlizedGet` and `graphGet` functions ready for easy data denormalization.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Anyone that uses [normalizr](https://github.com/paularmstrong/normalizr), or nor
 ## What does it do?
 
 1. `NormalizedGet` lets you access normalized data using a path as though it was denormalized. 
-2. `GraphGet` lets you denormalize mutliple paths at once, perfect for using in components.
+2. `GraphGet` lets you denormalize multiple paths at once, perfect for using in components.
 
 ### NormalizedGet
 
@@ -28,19 +28,19 @@ Say you have a schema like this:
 
 Just setup `bindNoramlizedGet` like so:
 ```js
-const normlizedGet = bindNormalizedGet(schemas, data); 
+const normalizedGet = bindNormalizedGet(schemas, data); 
 ```
 
 Now you can access deep relationships with a single line of code:
 
 ```js
 // With normalizedGet
-const commenters = normlizedGet('articles[123].comments.user');
+const commenters = normalizedGet('articles[123].comments.user');
 ```
 
 It even follows Array entities. So the above example will map over the comments and return the authors.
 
-For comparision, here's how you'd do it without `normlizedGet`:
+For comparison, here's how you'd do it without `normalizedGet`:
 ```js
 // Without normlaizedGet:
 const commenters = Object.keys(data.comments)
@@ -54,7 +54,7 @@ The more relationships your data has have the more complex this manual fetching 
 
 ### graphGet
 
-`normlizedGet` is nice for getting a specific peice of data from your entity graph. What if you need more data? That's where `graphGet` comes in handy. It returns a deep structure containing the data you specify.
+`normalizedGet` is nice for getting a specific piece of data from your entity graph. What if you need more data? That's where `graphGet` comes in handy. It returns a deep structure containing the data you specify.
 
 First we bind `graphGet` using the similar config method as before:
 ```js
@@ -98,4 +98,4 @@ export const normalizedGet = bindNormalizedGet(schemas, data);
 export const graphGet = bindGraphGet(schemas, data);
 ```
 
-Now you have `normlizedGet` and `graphGet` functions ready for easy data denormalization.
+Now you have `normalizedGet` and `graphGet` functions ready for easy data denormalization.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "lodash._stringtopath": "^4.8.0",
     "lodash.get": "^4.4.2",
-    "lodash.memoize": "^4.1.2",
     "lodash.mergewith": "^4.6.0"
   },
   "quokka": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash._stringtopath": "^4.8.0",
     "lodash.get": "^4.4.2",
     "lodash.memoize": "^4.1.2",
-    "lodash.merge": "^4.6.0"
+    "lodash.mergewith": "^4.6.0"
   },
   "quokka": {
     "babel": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel": "^6.23.0",
     "babel-cli": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
+    "babel-preset-stage-0": "^6.24.0",
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.3",
@@ -25,12 +26,14 @@
   "dependencies": {
     "lodash._stringtopath": "^4.8.0",
     "lodash.get": "^4.4.2",
-    "lodash.memoize": "^4.1.2"
+    "lodash.memoize": "^4.1.2",
+    "lodash.merge": "^4.6.0"
   },
   "quokka": {
     "babel": {
       "presets": [
-        "es2015"
+        "es2015",
+        "stage-0"
       ]
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,50 @@
 import lodashGet from 'lodash.get';
-import lodashMerge from 'lodash.merge';
+import lodashMergeWith from 'lodash.mergewith';
 import memoize from 'lodash.memoize';
 import stringToPath from 'lodash._stringtopath';
+
+const requireKnownSchema = (schema, modelName, path) => {
+  if (typeof schema === 'undefined') {
+    throw new Error(
+      `Could not find schema '${modelName}' for path [${path.join('.')}]. Availalbe schemas: [${Object.keys(schemas)}]`
+    );
+  }
+};
+
+const requireKnownProperty = (
+  propertyData,
+  modelData,
+  modelName,
+  propertyName,
+  path
+) => {
+  if (typeof propertyData === 'undefined') {
+    throw new Error(
+      `Could not find property '${propertyName}' on '${modelName}' for path [${path.join('.')}]. Available properties: [${Object.keys(modelData)}]`
+    );
+  }
+};
+
+const requireShouldFollowForRemainingPath = (
+  remainingPath,
+  path,
+  propertyName
+) => {
+  if (remainingPath.length) {
+    throw new Error(
+      `Cannot follow the remaining path '${remainingPath}' for path '${path.join('.')}' while denormalizing '${propertyName}' because the 'shouldFollow' option was not provided.`
+    );
+  }
+};
 
 const nget = (config, schemas, entities, path) => {
   const [modelName, id, propertyName, ...remainingPath] = path;
   const modelData = entities[modelName] && entities[modelName][id];
-  const { shouldFollow } = config;
+  const propertyData = modelData && modelData[propertyName];
+  const { shouldFollow, shouldMerge } = config;
+  const schema = schemas[modelName];
+  let results;
+
   if (!propertyName) {
     return modelData;
   } // No more properties to find. We're done.
@@ -15,184 +53,93 @@ const nget = (config, schemas, entities, path) => {
     return undefined;
   } // cache miss. Ignore.
 
-  const schema = schemas[modelName];
-  if (typeof schema === 'undefined') {
-    throw new Error(
-      `Could not find schema '${modelName}' for path [${path.join(', ')}]. Availalbe schemas: [${Object.keys(schemas)}]`,
-    );
-  }
-
-  const propertyData = modelData[propertyName]; // may be an array or value
-  if (typeof propertyData === 'undefined') {
-    throw new Error(
-      `Could not find property '${propertyName}' on '${modelName}' for path [${path.join(', ')}]. Available properties: [${Object.keys(modelData)}]`,
-    );
-  }
+  requireKnownSchema(schema, modelName, path);
+  requireKnownProperty(propertyData, modelData, modelName, propertyName, path);
 
   const propertySchema = schema.schema[propertyName];
 
-  // it's a normal non-relational property, defer to lodashGet
   if (!propertySchema) {
-    return (
-      !propertySchema && lodashGet(modelData, [propertyName, ...remainingPath])
-    );
-  }
-
-  // it's a hasMany relationship
-  if (Array.isArray(propertySchema)) {
+    // it's a normal non-relational property, defer to lodashGet
+    results = lodashGet(modelData, [propertyName, ...remainingPath]);
+  } else if (Array.isArray(propertySchema)) {
+    // it's a hasMany relationship
     const relatedModelsName = propertySchema[0].key;
-    // access related entity by key if provided
-    if (remainingPath.length && !shouldFollow) {
-      throw new Error(
-        "[TBD: error about there being a remaining path but shouldFollow isn't configured]",
-      );
+    if (!shouldFollow) {
+      requireShouldFollowForRemainingPath(remainingPath, path, propertyName);
     }
+
     // return all the related records
-    return propertyData.map(relatedId =>
+    results = propertyData.map(relatedId =>
       nget(config, schemas, entities, [
         relatedModelsName,
         relatedId,
-        ...remainingPath,
-      ]),
+        ...remainingPath
+      ])
     );
+  } else {
+    // it's a belongsTo relationship
+    const relatedModelName = propertySchema.key;
+    results = nget(config, schemas, entities, [
+      relatedModelName,
+      propertyData,
+      ...remainingPath
+    ]);
   }
 
-  // it's a belongsTo relationship
-  const relatedModelName = propertySchema.key;
-  return nget(config, schemas, entities, [
-    relatedModelName,
-    propertyData,
-    ...remainingPath,
-  ]);
+  return shouldMerge ? { ...modelData, [propertyName]: results } : results;
 };
 
-export const parsedNGet = (config = {}, schemas, entities, pathString) => {
+// _.mergeBy([{
+//   author: 123
+// }, {
+//   author: {}
+// }], (a, b) => {
+//   if [].concat(a)[0] or [].concat(b)[0] // is an object, choose that one
+//   // ["mystring"]
+//   // [{}, {}, {}]
+//   // 123 vs. [123, 4321, 5439]
+// })
+
+const parsedNGet = (config = {}, schemas, entities, pathString) => {
   const path = stringToPath(pathString);
   const rootModelName = path[0];
   if (typeof entities[rootModelName] === 'undefined') {
     const knownSchemas = Object.keys(schemas);
     throw new Error(
-      `Could not find property '${rootModelName}' for path '${pathString}'. Known keys: [${knownSchemas.join(',')}].`,
+      `Could not find property '${rootModelName}' for path '${pathString}'. Known keys: [${knownSchemas.join(',')}].`
     );
   }
   return nget(config, schemas, entities, path);
 };
 
+const preferObjectsCustomizer = (a, b) => {
+  const shouldPreserveObject =
+    typeof [].concat(a)[0] === 'object' && typeof [].concat(b)[0] === 'string';
+  return shouldPreserveObject ? a : b;
+};
+
+export const parsedNGetMulti = (
+  config = {},
+  schemas,
+  entities,
+  ...pathStrings
+) => {
+  const results = pathStrings.map(pathString =>
+    parsedNGet(config, schemas, entities, pathString)
+  );
+  console.log('results', results);
+
+  return lodashMergeWith({}, ...results, preferObjectsCustomizer);
+};
+
+// TODO: bind the data too
 export const bindNormalizedGet = (schemas, config) =>
   parsedNGet.bind(null, config, schemas);
 
-// --------------------------------------------
-
-export const bindNormalizedGetDeep = (schemas, config) =>
-  parsedNGet.bind(null, config, schemas);
-
-const ngetDeep = (config, schemas, entities, path) => {
-  const [modelName, id, propertyName, ...remainingPath] = path;
-  const modelData = entities[modelName] && entities[modelName][id];
-  const { shouldFollow } = config;
-  if (!propertyName) {
-    return modelData;
-  } // No more properties to find. We're done.
-
-  if (typeof modelData === 'undefined') {
-    return undefined;
-  } // cache miss. Ignore.
-
-  const schema = schemas[modelName];
-  if (typeof schema === 'undefined') {
-    throw new Error(
-      `Could not find schema '${modelName}' for path [${path.join(', ')}]. Availalbe schemas: [${Object.keys(schemas)}]`,
-    );
-  }
-
-  const propertyData = modelData[propertyName]; // may be an array or value
-  if (typeof propertyData === 'undefined') {
-    throw new Error(
-      `Could not find property '${propertyName}' on '${modelName}' for path [${path.join(', ')}]. Available properties: [${Object.keys(modelData)}]`,
-    );
-  }
-
-  const propertySchema = schema.schema[propertyName];
-
-  // it's a normal non-relational property, defer to lodashGet
-  if (!propertySchema) {
-    const subProperty =
-      !propertySchema && lodashGet(modelData, [propertyName, ...remainingPath]);
-    return { ...modelData, [propertyName]: subProperty };
-  }
-
-  // it's a hasMany relationship
-  if (Array.isArray(propertySchema)) {
-    const relatedModelsName = propertySchema[0].key;
-    // access related entity by key if provided
-    if (remainingPath.length && !shouldFollow) {
-      throw new Error(
-        "[TBD: error about there being a remaining path but shouldFollow isn't configured]",
-      );
-    }
-    // return all the related records
-    const subRecords = propertyData.map(relatedId =>
-      ngetDeep(config, schemas, entities, [
-        relatedModelsName,
-        relatedId,
-        ...remainingPath,
-      ]),
-    );
-    return { ...modelData, [propertyName]: subRecords };
-  }
-
-  // it's a belongsTo relationship
-  const relatedModelName = propertySchema.key;
-  console.log('path', path);
-
-  const subRecord = ngetDeep(config, schemas, entities, [
-    relatedModelName,
-    propertyData,
-    ...remainingPath,
-  ]); /* ?*/
-  return { ...modelData, [propertyName]: subRecord };
-};
-
-// ----------------------
-import { schema } from 'normalizr';
-import { articlesCommentsUsers as data } from '../test/fixtures';
-
-const makeSchemas = () => {
-  const users = new schema.Entity('users');
-  const comments = new schema.Entity('comments', {
-    user: users,
-  });
-  const articles = new schema.Entity('articles', {
-    author: users,
-    comments: [comments],
-  });
-  return { comments, articles, users };
-};
-
-// const ngetDeep = bindNormalizedGetDeep(makeSchemas);
-
-const results = ngetDeep(
-  { shouldFollow: true },
-  makeSchemas(),
-  data,
-  // 'articles.123.author'.split('.'),
-  'articles.123.comments.user'.split('.'),
-);
-
-JSON.stringify(results); /* ?*/
-
-// const schemas = makeSchemas();
-
-// const mGetTestFOOOO = (config, schemas, entities, ...paths) => {
-//   const denormalized = paths.map(path => {}
-//     nget(config, schemas, entities, path)
-//   );
-//   console.log("denormalized", denormalized);
-//   return lodashMerge({}, ...denormalized);
-// };
-
-// export const bindMergedGet = schemas =>
-//   mGetTestFOOOO.bind(null, { shouldFollow: true }, schemas); // TODO: Obvs
-
-// const fooMergedGet = bindMergedGet(makeSchemas());
-// fooMergedGet(data, 'articles.123'.split('.')); /* ?*/
+export const bindGraphGet = (schemas, entities) =>
+  parsedNGetMulti.bind(
+    null,
+    { shouldMerge: true, shouldFollow: true },
+    schemas,
+    entities
+  );

--- a/src/index.js
+++ b/src/index.js
@@ -1,58 +1,182 @@
 import lodashGet from 'lodash.get';
+import lodashMerge from 'lodash.merge';
 import memoize from 'lodash.memoize';
 import stringToPath from 'lodash._stringtopath';
 
-const nget = (schemas, entities, path) => {
+const nget = (config, schemas, entities, path) => {
   const [modelName, id, propertyName, ...remainingPath] = path;
   const modelData = entities[modelName] && entities[modelName][id];
-  if (!propertyName) { return modelData; } // No more properties to find. We're done.
+  const { shouldFollow } = config;
+  if (!propertyName) {
+    return modelData;
+  } // No more properties to find. We're done.
 
-  if (typeof modelData === 'undefined') { return undefined; }  // cache miss. Ignore.
+  if (typeof modelData === 'undefined') {
+    return undefined;
+  } // cache miss. Ignore.
 
   const schema = schemas[modelName];
-  if (typeof schema === 'undefined') { 
-    throw new Error(`Could not find schema '${modelName}' for path [${path.join(', ')}]. Availalbe schemas: [${Object.keys(schemas)}]`); 
+  if (typeof schema === 'undefined') {
+    throw new Error(
+      `Could not find schema '${modelName}' for path [${path.join(', ')}]. Availalbe schemas: [${Object.keys(schemas)}]`
+    );
   }
 
-  const propertyData = modelData[propertyName];  // may be an array or value
+  const propertyData = modelData[propertyName]; // may be an array or value
   if (typeof propertyData === 'undefined') {
-    throw new Error(`Could not find property '${propertyName}' on '${modelName}' for path [${path.join(', ')}]. Available properties: [${Object.keys(modelData)}]`);
+    throw new Error(
+      `Could not find property '${propertyName}' on '${modelName}' for path [${path.join(', ')}]. Available properties: [${Object.keys(modelData)}]`
+    );
   }
 
   const propertySchema = schema.schema[propertyName];
 
   // it's a normal non-relational property, defer to lodashGet
-  if (!propertySchema) {  
-    return !propertySchema && lodashGet(modelData, [propertyName, ...remainingPath]);
+  if (!propertySchema) {
+    return (
+      !propertySchema && lodashGet(modelData, [propertyName, ...remainingPath])
+    );
   }
 
   // it's a hasMany relationship
   if (Array.isArray(propertySchema)) {
     const relatedModelsName = propertySchema[0].key;
-    if (remainingPath.length) {
-      const [pathHead, ...pathTail] = remainingPath;
-      const relatedModelsIdByIndex = propertyData[pathHead];
-      return nget(schemas, entities, [relatedModelsName, relatedModelsIdByIndex, ...pathTail]);
+    // access related entity by key if provided
+    if (remainingPath.length && !shouldFollow) {
+      throw new Error(
+        "[TBD: error about there being a remaining path but shouldFollow isn't configured]"
+      );
     }
     // return all the related records
-    return propertyData.map((relatedId) => {
-      return nget(schemas, entities, [relatedModelsName, relatedId]);
-    });
+    return propertyData.map(relatedId =>
+      nget(config, schemas, entities, [
+        relatedModelsName,
+        relatedId,
+        ...remainingPath
+      ])
+    );
   }
 
   // it's a belongsTo relationship
   const relatedModelName = propertySchema.key;
-  return nget(schemas, entities, [relatedModelName, propertyData, ...remainingPath]);
+  return nget(config, schemas, entities, [
+    relatedModelName,
+    propertyData,
+    ...remainingPath
+  ]);
 };
 
-export const parsedNGet = (schemas, entities, pathString) => {
+export const parsedNGet = (config = {}, schemas, entities, pathString) => {
   const path = stringToPath(pathString);
   const rootModelName = path[0];
   if (typeof entities[rootModelName] === 'undefined') {
     const knownSchemas = Object.keys(schemas);
-    throw new Error(`Could not find property '${rootModelName}' for path '${pathString}'. Known keys: [${knownSchemas.join(',')}].`); 
+    throw new Error(
+      `Could not find property '${rootModelName}' for path '${pathString}'. Known keys: [${knownSchemas.join(',')}].`
+    );
   }
-  return nget(schemas, entities, path);
+  return nget(config, schemas, entities, path);
 };
 
-export const bindNormalizedGet = (schemas) => parsedNGet.bind(null, schemas);
+export const bindNormalizedGet = (schemas, config) =>
+  parsedNGet.bind(null, config, schemas);
+
+// ----------------------
+// const iget = (schemas, entities, path) => {
+//   const [modelName, id, propertyName, ...remainingPath] = path;
+//   const modelData = entities[modelName] && entities[modelName][id];
+//   if (!propertyName) { return modelData; } // No more properties to find. We're done.
+
+//   if (typeof modelData === 'undefined') { return undefined; }  // cache miss. Ignore.
+
+//   const schema = schemas[modelName];
+//   if (typeof schema === 'undefined') {
+//     throw new Error(`Could not find schema '${modelName}' for path [${path.join(', ')}]. Availalbe schemas: [${Object.keys(schemas)}]`);
+//   }
+
+//   const propertyData = modelData[propertyName];  // may be an array or value
+//   if (typeof propertyData === 'undefined') {
+//     throw new Error(`Could not find property '${propertyName}' on '${modelName}' for path [${path.join(', ')}]. Available properties: [${Object.keys(modelData)}]`);
+//   }
+
+//   const propertySchema = schema.schema[propertyName];
+
+//   // it's a normal non-relational property, defer to lodashGet
+//   if (!propertySchema) {
+//     return !propertySchema && lodashGet(modelData, [propertyName, ...remainingPath]);
+//   }
+
+//   // it's a hasMany relationship
+//   if (Array.isArray(propertySchema)) {
+//     const relatedModelsName = propertySchema[0].key;
+//     if (remainingPath.length) {
+//       const [pathHead, ...pathTail] = remainingPath;
+//       const relatedModelsIdByIndex = propertyData[pathHead];
+//       return iget(schemas, entities, [relatedModelsName, relatedModelsIdByIndex, ...pathTail]);
+//     }
+
+//     // return all the related records
+//     const denormalizedData = propertyData.map((relatedId) =>
+//       iget(schemas, entities, [relatedModelsName, relatedId] )
+//     );
+//     return [modelData, { [propertyName]: denormalizedData }];
+//     // return {
+//     //   ...modelData,
+//     //   [propertyName]: denormalizedData,
+//     // };
+//   }
+
+//   // it's a belongsTo relationship
+//   const relatedModelName = propertySchema.key;
+//   return {
+//     ...modelData,
+//     [propertyName]: iget(schemas, entities, [relatedModelName, propertyData, ...remainingPath]),
+//   };
+// };
+
+// ----------------------
+import { schema } from 'normalizr';
+import { articlesCommentsUsers as data } from '../test/fixtures';
+
+const makeSchemas = () => {
+  const users = new schema.Entity('users');
+  const comments = new schema.Entity('comments', {
+    user: users
+  });
+  const articles = new schema.Entity('articles', {
+    author: users,
+    comments: [comments]
+  });
+  return { comments, articles, users };
+};
+
+// const schemas = makeSchemas();
+
+const mGetTestFOOOO = (config, schemas, entities, ...paths) => {
+  const denormalized = paths.map(path => nget(config, schemas, entities, path));
+  console.log("denormalized", denormalized);
+  
+  return lodashMerge({}, ...denormalized);
+};
+
+export const bindMergedGet = schemas =>
+  mGetTestFOOOO.bind(null, { shouldFollow: true }, schemas); // TODO: Obvs
+
+const fooMergedGet = bindMergedGet(makeSchemas());
+fooMergedGet(data, 'articles.123'.split('.')); /* ?*/
+
+// iget(schemas, data, 'articles.123.author'.split('.'));
+
+// const multiget = (...paths) => paths.reduce((acc, path) => {
+//   const results = iget(schemas, data, path.split('.')); /* ?*/
+//   return {
+//       ...acc,
+//       ...results,
+//     };
+// }, {});
+
+// const article = multiget(
+//   'articles.123.comments',
+//   'articles.123.author',
+//   // 'articles.123.title',
+// );

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import { schema } from 'normalizr';
-import { bindNormalizedGet } from '../src/index';
+import { bindNormalizedGet, bindMergedGet } from '../src/index';
 import { articlesCommentsUsers as data } from './fixtures';
 
 const { expect } = chai;
@@ -8,11 +8,11 @@ const { expect } = chai;
 const makeSchemas = () => {
   const users = new schema.Entity('users');
   const comments = new schema.Entity('comments', {
-    user: users,
+    user: users
   });
   const articles = new schema.Entity('articles', {
     author: users,
-    comments: [comments],
+    comments: [comments]
   });
   return { comments, articles, users };
 };
@@ -32,16 +32,19 @@ describe('Normalized Get', () => {
 
   it('should return resolved entities for 1-to-many relationships', () => {
     const actual = nget(data, 'articles[123].comments');
-    const expected = [data.comments['comment-123-4738'], data.comments['comment-123-9999']]
+    const expected = [
+      data.comments['comment-123-4738'],
+      data.comments['comment-123-9999']
+    ];
     expect(actual).to.include.members(expected);
   });
 
   it('should return resolved entities for 1-to-1 relationships', () => {
-    const actual = nget(data, 'comments[comment-123-9999].user');  
-    expect(actual).to.equal(data.users['8472'])
+    const actual = nget(data, 'comments[comment-123-9999].user');
+    expect(actual).to.equal(data.users['8472']);
   });
 
-  it('should access resolved entities by index', () => {
+  it.skip('should access resolved entities by index', () => {
     const actual = nget(data, 'articles[123].comments[0]');
     expect(actual).to.equal(data.comments['comment-123-4738']);
   });
@@ -57,7 +60,55 @@ describe('Normalized Get', () => {
   });
 
   it('should throw an error for missing properties', () => {
-    const fn = () => { nget(data, 'articles[123].nonExistantRelation'); };
-    expect(fn).to.throw('Could not find property \'nonExistantRelation\' on \'articles\' for path [articles, 123, nonExistantRelation]. Available properties: [author,body,comments,id,title]');
+    const fn = () => {
+      nget(data, 'articles[123].nonExistantRelation');
+    };
+    expect(fn).to.throw(
+      "Could not find property 'nonExistantRelation' on 'articles' for path [articles, 123, nonExistantRelation]. Available properties: [author,body,comments,id,title]"
+    );
+  });
+});
+
+describe('Normalized Get when follow option is true', () => {
+  const ngetFollow = bindNormalizedGet(makeSchemas(), { shouldFollow: true });
+
+  it('should map over array results and apply the remaining path', () => {
+    const actual = ngetFollow(data, 'articles[123].comments.comment');
+    expect(actual).to.include.members(
+      Object.keys(data.comments).map(key => data.comments[key].comment)
+    );
+  });
+
+  it('should map over array results and apply the remaining deep path', () => {
+    const actual = ngetFollow(data, 'articles[123].comments.user.name');
+    const expected = Object.keys(data.comments)
+      .map(key => data.comments[key])
+      .map(comment => data.users[comment.user].name);
+    expect(actual).to.include.members(expected);
+  });
+});
+
+describe.only('Merged Normalized Get', () => {
+  const mergedGet = bindMergedGet(makeSchemas());
+
+  it('should merge two sibling paths', () => {
+    const actual = mergedGet(
+      data,
+      'articles.123'.split('.'),
+      'articles.123.comments'.split('.'),
+      'articles.123.author'.split('.')
+    );
+    const article = data.articles[123];
+    const comments = Object.keys(data.comments).map(key => data.comments[key]);
+    const author = data.users[data.articles[123].author];
+
+    const expected = {
+      ...article,
+      ...{ comments },
+      ...{ author }
+    };
+    console.log('expected', expected);
+
+    expect(actual).to.equal(expected);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -18,20 +18,20 @@ const makeSchemas = () => {
 };
 
 describe('Normalized Get', () => {
-  const nget = bindNormalizedGet(makeSchemas());
+  const nget = bindNormalizedGet(makeSchemas(), data);
 
   it('should find a top-level model', () => {
-    const actual = nget(data, 'articles[123]');
+    const actual = nget('articles[123]');
     expect(actual.id).to.equal('123');
   });
 
   it('should return an empty object for entities not in data', () => {
-    const actual = nget(data, 'articles[9999999]');
+    const actual = nget('articles[9999999]');
     expect(actual).to.be.undefined;
   });
 
   it('should return resolved entities for 1-to-many relationships', () => {
-    const actual = nget(data, 'articles[123].comments');
+    const actual = nget('articles[123].comments');
     const expected = [
       data.comments['comment-123-4738'],
       data.comments['comment-123-9999']
@@ -40,59 +40,60 @@ describe('Normalized Get', () => {
   });
 
   it('should return resolved entities for 1-to-1 relationships', () => {
-    const actual = nget(data, 'comments[comment-123-9999].user');
+    const actual = nget('comments[comment-123-9999].user');
     expect(actual).to.equal(data.users['8472']);
   });
 
-  it.skip('should access resolved entities by index', () => {
-    const actual = nget(data, 'articles[123].comments[0]');
-    expect(actual).to.equal(data.comments['comment-123-4738']);
-  });
-
   it('should access non-relational properties', () => {
-    const actual = nget(data, 'articles[123].body');
+    const actual = nget('articles[123].body');
     expect(actual).to.equal(data.articles[123].body);
   });
 
   it('should access chained non-relational properties', () => {
-    const actual = nget(data, 'articles[123].body.length');
+    const actual = nget('articles[123].body.length');
     expect(actual).to.equal(data.articles[123].body.length);
   });
 
-  it('should throw an error for missing properties', () => {
-    const fn = () => {
-      nget(data, 'articles[123].nonExistantRelation');
-    };
-    expect(fn).to.throw(
-      "Could not find property 'nonExistantRelation' on 'articles' for path [articles.123.nonExistantRelation]. Available properties: [author,body,comments,id,title]"
-    );
-  });
-});
-
-describe('Normalized Get when shouldFollow option is true', () => {
-  const ngetFollow = bindNormalizedGet(makeSchemas(), { shouldFollow: true });
-
   it('should map over array results and apply the remaining path', () => {
-    const actual = ngetFollow(data, 'articles[123].comments.comment');
+    const actual = nget('articles[123].comments.comment');
     expect(actual).to.include.members(
       Object.keys(data.comments).map(key => data.comments[key].comment)
     );
   });
 
   it('should map over array results and apply the remaining deep path', () => {
-    const actual = ngetFollow(data, 'articles[123].comments.user.name');
+    const actual = nget('articles[123].comments.user.name');
     const expected = Object.keys(data.comments)
       .map(key => data.comments[key])
       .map(comment => data.users[comment.user].name);
     expect(actual).to.include.members(expected);
   });
+
+  it('should throw an error for missing properties', () => {
+    const fn = () => {
+      nget('articles[123].nonExistantRelation');
+    };
+    expect(fn).to.throw(
+      "Could not find property 'nonExistantRelation' on 'articles' for path [articles.123.nonExistantRelation]. Available properties: [author,body,comments,id,title]"
+    );
+  });
+
+  it('should throw an error for missing schemas', () => {
+    const fn = () => {
+      console.log('here')
+      nget('thisIsNotReal[123]');
+    };
+    expect(fn).to.throw(
+      "Could not find schema 'thisIsNotReal' for path 'thisIsNotReal[123]'. Known schemas: [comments,articles,users]."
+    );    
+  })
 });
 
 describe('Graph Get', () => {
-  const ngetMerged = bindGraphGet(makeSchemas(), data);
+  const graphGet = bindGraphGet(makeSchemas(), data);
 
   it('should return a deeply nested object', () => {
-    const actual = ngetMerged('articles[123].author');
+    const actual = graphGet('articles[123].author');
     const article = data.articles[123];
     const author = data.users[article.author];
     const expected = { ...article, ...{ author } };
@@ -100,7 +101,7 @@ describe('Graph Get', () => {
   });
 
   it('should merge multiple paths', () => {
-    const actual = ngetMerged(
+    const actual = graphGet(
       'articles[123].author',
       'articles[123].comments',
       'articles[123]'

--- a/test/index.js
+++ b/test/index.js
@@ -70,23 +70,18 @@ describe('Normalized Get', () => {
   });
 
   it('should throw an error for missing properties', () => {
-    const fn = () => {
-      nget('articles[123].nonExistantRelation');
-    };
+    const fn = () => nget('articles[123].nopeNotReal');
     expect(fn).to.throw(
-      "Could not find property 'nonExistantRelation' on 'articles' for path [articles.123.nonExistantRelation]. Available properties: [author,body,comments,id,title]"
+      "Could not find property 'nopeNotReal' on 'articles' for path [articles.123.nopeNotReal]. Available properties: [author,body,comments,id,title]"
     );
   });
 
   it('should throw an error for missing schemas', () => {
-    const fn = () => {
-      console.log('here')
-      nget('thisIsNotReal[123]');
-    };
+    const fn = () => nget('thisIsNotReal[123]');
     expect(fn).to.throw(
       "Could not find schema 'thisIsNotReal' for path 'thisIsNotReal[123]'. Known schemas: [comments,articles,users]."
-    );    
-  })
+    );
+  });
 });
 
 describe('Graph Get', () => {
@@ -96,7 +91,9 @@ describe('Graph Get', () => {
     const actual = graphGet('articles[123].author');
     const article = data.articles[123];
     const author = data.users[article.author];
-    const expected = { ...article, ...{ author } };
+    const expected = {
+      articles: { 123: { ...article, ...{ author } } }
+    };
     expect(actual).to.deep.equal(expected);
   });
 
@@ -109,7 +106,23 @@ describe('Graph Get', () => {
     const article = data.articles[123];
     const author = data.users[article.author];
     const comments = Object.keys(data.comments).map(key => data.comments[key]);
-    const expected = { ...article, ...{ author }, ...{ comments } };
+    const expected = {
+      articles: { 123: { ...article, ...{ author }, ...{ comments } } }
+    };
+    
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('should hashmap multiple root models', () => {
+    const actual = graphGet(
+      'comments[comment-123-4738]',
+      'comments[comment-123-9999]'
+    );
+    const commentA = data.comments['comment-123-4738'];
+    const commentB = data.comments['comment-123-9999'];
+    const expected = {
+      comments: { 'comment-123-4738': commentA, 'comment-123-9999': commentB }
+    };
     expect(actual).to.deep.equal(expected);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,22 @@ babel-generator@^6.24.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+babel-helper-bindify-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-helper-call-delegate@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz#119921b56120f17e9dae3f74b4f5cc7bcc1b37ef"
@@ -211,6 +227,23 @@ babel-helper-define-map@^6.23.0:
     babel-types "^6.23.0"
     lodash "^4.2.0"
 
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-explode-class@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
+  dependencies:
+    babel-helper-bindify-decorators "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-function-name@^6.22.0, babel-helper-function-name@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
@@ -221,12 +254,29 @@ babel-helper-function-name@^6.22.0, babel-helper-function-name@^6.23.0:
     babel-traverse "^6.23.0"
     babel-types "^6.23.0"
 
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  dependencies:
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-get-function-arity@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz#0beb464ad69dc7347410ac6ade9f03a50634f5ce"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
 babel-helper-hoist-variables@^6.22.0:
   version "6.22.0"
@@ -249,6 +299,16 @@ babel-helper-regex@^6.22.0:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
     lodash "^4.2.0"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-replace-supers@^6.22.0, babel-helper-replace-supers@^6.23.0:
   version "6.23.0"
@@ -278,6 +338,104 @@ babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-class-constructor-call@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz#9cb9d39fe43c8600bec8146456ddcbd4e1a76416"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-decorators@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-do-expressions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz#5747756139aa26d390d09410b03744ba07e4796d"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-export-extensions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
+
+babel-plugin-syntax-function-bind@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz#48c495f177bdf31a981e732f55adc0bdd2601f46"
+
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-constructor-call@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
+  dependencies:
+    babel-plugin-syntax-class-constructor-call "^6.18.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
+  dependencies:
+    babel-helper-explode-class "^6.24.1"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-do-expressions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz#28ccaf92812d949c2cd1281f690c8fdc468ae9bb"
+  dependencies:
+    babel-plugin-syntax-do-expressions "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
@@ -448,6 +606,35 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-exponentiation-operator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-extensions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz#53738b47e75e8218589eea946cbbd39109bbe653"
+  dependencies:
+    babel-plugin-syntax-export-extensions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-function-bind@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz#c6fb8e96ac296a310b8cf8ea401462407ddf6a97"
+  dependencies:
+    babel-plugin-syntax-function-bind "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"
@@ -498,6 +685,41 @@ babel-preset-es2015@^6.24.0:
     babel-plugin-transform-es2015-unicode-regex "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
 
+babel-preset-stage-0@^6.24.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz#5642d15042f91384d7e5af8bc88b1db95b039e6a"
+  dependencies:
+    babel-plugin-transform-do-expressions "^6.22.0"
+    babel-plugin-transform-function-bind "^6.22.0"
+    babel-preset-stage-1 "^6.24.1"
+
+babel-preset-stage-1@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz#7692cd7dcd6849907e6ae4a0a85589cfb9e2bfb0"
+  dependencies:
+    babel-plugin-transform-class-constructor-call "^6.24.1"
+    babel-plugin-transform-export-extensions "^6.22.0"
+    babel-preset-stage-2 "^6.24.1"
+
+babel-preset-stage-2@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators "^6.24.1"
+    babel-preset-stage-3 "^6.24.1"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
+
 babel-register@^6.24.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.0.tgz#5e89f8463ba9970356d02eb07dabe3308b080cfd"
@@ -527,6 +749,16 @@ babel-template@^6.22.0, babel-template@^6.23.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
+babel-template@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
 babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
@@ -541,9 +773,32 @@ babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
 babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
@@ -1597,6 +1852,10 @@ lodash.keys@^3.0.0:
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,9 +1853,9 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.merge@^4.6.0:
+lodash.mergewith@^4.6.0:
   version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"


### PR DESCRIPTION
## Added
* New `bindGraphGet` which returns multiple paths deep merged together. Useful for denormalizing a section of the entity graph.

## Changed
* Breaking: Schemas and data are now pre-bound. This changes the signature of the bound getter from `nget(data, pathString)` to simply `nget(pathString)`.